### PR TITLE
Workshop page

### DIFF
--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -60,7 +60,7 @@
             We are accepting extended abstract submissions for position, review, or research results (up to 2 pages, excluding references). Shorter versions (up to 6 pages, excluding references) of articles in submission or accepted at other venues (or presented after Oct. 1, 2024) are acceptable as long as they do not violate the dual-submission policy of the other venue. All submissions will undergo peer review and authors will have the option to publish their work in arXiv proceedings.
         </p>
         <div class="hero-button">
-            <a href="URL_HERE" target="_blank">Apply Today!</a>
+            <a href="https://cmt3.research.microsoft.com/HDRAnomaly25" target="_blank">Apply Today!</a>
         </div>
         <h2>Organizing Committee</h2>
         <ul>


### PR DESCRIPTION
Adjusts the formatting of the workshop page: Everything aligned left, but buttons and video still centered. Also adds the URL to apply to the conference on the CMT page (link will work upon site approval, probably tomorrow).