### PR TITLE
Add challenge end date to website

### DIFF
--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -49,6 +49,9 @@
     </div>
 
     <hr>
+
+        <h3>The ML Challenge runs through January 17th, 2025.</h3>
+    
         <!-- Embed the video below this section -->
     <div class="video-container">
         <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>    </div>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
             <br><br>
          Depending on the scientific domain, a <b>new, unpredictable object/event</b> could have a profound impact. This could be a new type of material, the discovery of a <b>new astrophysical object</b> 🌌, the observation of <b>unusual climate behavior</b> 🌦️, or the discovery of a <b>new species</b> 🦋. The observation of something different, incongruous with the data, is what we call <b>anomaly detection</b> 🔍. Looking for anomalies is often quite different than other tasks since we do not know what exactly to look for, we just need to look for <b>something different</b>.
          <br><br>
-        The challenge of scientific anomaly detection is one of the main focuses. <b>Using machine learning</b> to identify these anomalies 🤖
+         The main focus of this challenge is the application of <b>machine learning</b> to scientific anomaly detection 🤖.
         <br><br> </p1>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
         <br><br> </p1>
         </div>
 
+        <h3>The ML Challenge runs through January 17th, 2025.</h3>
+
     <!-- Embed the video below this section -->
     <div class="video-container">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>    </div>


### PR DESCRIPTION
Added as headers on main page and workshop page (at call for participation in challenge) for clear visibility.