### PR TITLE
Add Challenge Organizers to challenge homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,60 @@
         <a href="rules.html" target="_blank">Participate in the Anomaly Detection challenge</a>
     </div>
 
+    <h2>Challenge Organizers</h2>
+    <div class="text-row">
+        <div class="col">
+            <h3>Imageomics</h3>
+            <ul style="list-style-type:none;">
+                <li>Elizabeth G. Campolongo</li>
+                <li>Wei-Lun Chao</li>
+                <li>Hilmar Lapp</li>
+            </ul>  
+        </div>
+        <div class="col">
+            <h3>A3D3</h3>
+            <ul style="list-style-type:none;">
+                <li>Yuan-Tang Chou</li>
+                <li>Ekaterina Govorkova</li>
+                <li>Philip Harris</li>
+                <li>Shih-Chieh Hsu</li>
+                <li>Mark S. Neubauer</li>
+            </ul> 
+        </div>
+        <div class="col">
+            <h3>iHarp</h3>
+            <ul style="list-style-type:none;">
+                <li>Josephine Namayanja</li>
+                <li>Aneesh Subramanian</li>
+            </ul> 
+        </div>
+    </div>
+    <h2>Student Organizers</h2>
+    <div class="text-row">
+        <div class="col">
+            <h3>Imageomics</h3>
+            <ul style="list-style-type:none;">
+                <li>Jiaman Wu</li>
+                <li>David E. Carlyn</li>
+                <li>Christopher Lawrence</li>
+                <li>Ziheng Zhang</li>
+            </ul>  
+        </div>
+        <div class="col">
+            <h3>A3D3</h3>
+            <ul style="list-style-type:none;">
+                <li>Advaith Anand</li>
+                <li>Eric Moreno</li>
+                <li>Ryan Raikman</li>
+            </ul> 
+        </div>
+        <div class="col">
+            <h3>iHarp</h3>
+            <ul style="list-style-type:none;">
+                <li>Subhankar Ghosh</li>
+            </ul> 
+        </div>
+    </div>
     </section>
 
     <div class="image-row">

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,22 @@ h2 {
     margin-top: 50px;
 }
 
+/* 
+Create Section for Challenge Organizers
+Organized in one row with three columns (one per Institute)
+Following: https://www.w3schools.com/howto/howto_css_three_columns.asp
+*/
+.text-row:after {
+    content: "";
+    display: table;
+    justify-content: center;
+    clear: both;
+}
+.col {
+    float: left;
+    width: 33.33%;
+}
+
 .circle {
     width: auto;
     height: auto;


### PR DESCRIPTION
Adds two sections to the homepage listing Challenge organizers. Columns are ordered to match the challenge image/links below this section. 
![Organizer Section](https://github.com/user-attachments/assets/8444b227-243f-465c-8ff6-ab24a96b7c8a)
