### PR TITLE
Add workshop schedule, papers, and posters to website

### DIFF
--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,14 +8,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap" rel="stylesheet">
     <style>
         .video-container {
-            margin-top: 20px;
-            /* Adjust the value to control the space between button and video */
-            text-align: center;
-            /* Optional: Center the video */
+            margin-top: 20px; /* Adjust the value to control the space between button and video */
+            text-align: center; /* Optional: Center the video */
         }
     </style>
 </head>
-
 <body>
 
     <div id="header"></div>
@@ -24,302 +20,126 @@
     <section class="hero">
         <div id="logo"></div>
         <div class="hero-content" id="workshop-content">
-            <h1>Anomaly Detection in Scientific Domains AAAI Workshop</h1>
+        <h1>Anomaly Detection in Scientific Domains AAAI Workshop</h1> 
             <h3>Tuesday, March 4, 2025 from 9am to 6pm</h3>
             <h3>Philadeliphia, PA, USA</h3>
-            <h2>Description</h2>
-            <p>
-                Scientific discovery often involves the observation of an inconsistency among “normal” patterns within
-                our data. The observation of something different, incongruous with the data, is what we call anomaly
-                detection.
-                Looking for anomalies is quite different from other tasks since we do not know what exactly to look
-                for—we just need to look for something different. The goal of this workshop is to nurture the community
-                of researchers working at the intersection of machine learning and various scientific domains toward
-                scientific discovery.
-            </p>
-            <p>
-                This workshop will also serve as the award ceremony with special recognition of the winners for the <a
-                    href="https://www.nsfhdr.org/mlchallenge" target="_blank">1st HDR Interdisciplinary Machine Learning
-                    Challenge</a> focusing on anomaly detection.
-                The challenge is a series of 4 challenges one for each of three distinct scientific domains (biology,
-                physics, and climate science), and a combined challenge across domains. A critical element of this
-                challenge was the integration of FAIR and Reproducible science.
-            </p>
+        <h2>Description</h2>
+        <p>
+            Scientific discovery often involves the observation of an inconsistency among “normal” patterns within our data. The observation of something different, incongruous with the data, is what we call anomaly detection. 
+            Looking for anomalies is quite different from other tasks since we do not know what exactly to look for—we just need to look for something different. The goal of this workshop is to nurture the community of researchers working at the intersection of machine learning and various scientific domains toward scientific discovery. 
+        </p>
+        <p>
+            This workshop will also serve as the award ceremony with special recognition of the winners for the <a href="https://www.nsfhdr.org/mlchallenge" target="_blank">1st HDR Interdisciplinary Machine Learning Challenge</a> focusing on anomaly detection. 
+            The challenge is a series of 4 challenges one for each of three distinct scientific domains (biology, physics, and climate science), and a combined challenge across domains. A critical element of this challenge was the integration of FAIR and Reproducible science. 
+        </p>
+       
+        <h2>Format</h2>
+        <p>
+            Our 1-day workshop will include keynote/invited talks, contributed paper presentations, a poster session, a panel discussion, and winning team presentations of their solutions to the challenge.
+        </p>
+        <h2>Attendance</h2>
+        <p>
+            The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
+        </p>
 
-            <h2>Format</h2>
-            <p>
-                Our 1-day workshop will include keynote/invited talks, contributed paper presentations, a poster
-                session, a panel discussion, and winning team presentations of their solutions to the challenge.
-            </p>
-            <h2>Attendance</h2>
-            <p>
-                The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics
-                such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific
-                discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary
-                research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
-            </p>
+        <hr>
 
-            <hr>
+        <div style="color:#6a1b9a">
+            <h1>Workshop Program</h1>
+    </div>
 
-            <div style="color:#6a1b9a">
-                <h1>Workshop Program</h1>
-            </div>
+    <hr>
+    <div id="schedule">
+    <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
+    <p><b>9:10 - 9:45am</b>: Eric Nalisnick&mdash;<b>Anomalous Anomalies: Monitoring and Adapting Anomaly Detectors</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/enalisnick/enalisnick.github.io/blob/master/Nalisnick_Headshot.jpeg?raw=true" alt="image of Eric Nalisnick" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Eric Nalisnick is an assistant professor at Johns Hopkins University. His research interests span statistical machine learning and probabilistic modeling, with an emphasis on quantifying uncertainty in deep learning, human-AI collaboration, specifying prior knowledge, and detecting distribution shift. He previously was an assistant professor at the University of Amsterdam, a postdoctoral researcher at the University of Cambridge and a PhD student at the University of California, Irvine. Eric has also held research positions at DeepMind, Microsoft, Twitter, and Amazon. His papers have been recognized with selective oral presentations (ECCV 2024) and awards (AIStats 2023, AIStats 2024).</p>
+            <p><b>Abstract:</b> Anomaly detectors perform essential tasks ranging from protecting an autonomous system from abnormal inputs to isolating interesting scientific signals that may lead to discovery.  However, how do we know that the anomaly detector will be robust?  The detector itself could be susceptible to failure if there is a change in the distribution of anomalies expected.  And to make matters worse, we usually don't have an abundance of test-time anomalies that are labeled as such.  In this talk, I will discuss my group's recent work on monitoring if our anomaly detector is still valid and adapting it to data shift, without supervision.</p>
+        </details></p>
+    <p><b>9:45 - 10:20am</b>: Jennifer Ngadiuba&mdash;<b>Boosting sensitivity to new physics at the LHC with anomaly detection</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/user-attachments/assets/5e2532ee-0090-4725-8bb8-58cee458e3ea" alt="image of Jennifer Ngadiuba" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Jennifer Ngadiuba, a Wilson Fellow at Fermilab since 2021, specializes in searching for new physics in collider data and advancing AI applications in high-energy physics. After earning her Ph.D. from the University of Zurich, she contributed to CMS experiment studies, focusing on diboson resonances and jet substructure techniques. Starting when she was research fellow at CERN and Caltech, she pioneered deep learning for anomaly detection and fast machine learning on FPGAs for real-time systems in particle physics. Her work earned her the DOE AI4HEP award and AI2050 fellowship in 2023, recognizing her transformative contributions to experimental physics and machine learning.</p>
+            <p><b>Abstract:</b> Anomaly detection techniques have been proposed as a way to mitigate the impact of
+                model-specific assumptions when searching for new physics at the LHC. In this talk I will
+                discuss how these techniques, when based on modern AI developments, could be utilized
+                at different stages of data processing workflow, from real-time systems to offline analysis,
+                and the impact they could have to revolutionize the current paradigms in the search for
+                new physics.</p>
+        </details></p>
+    <p><b>10:30 - 11:30am</b>: Coffee Break and Poster Session (<a href="#papers-posters">Papers and Associated Posters</a>)</p>
+    <p><b>11:30 - 12:10pm</b>: Adji Bousso Dieng&mdash;<b>Vendi Scoring For Discovery</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/user-attachments/assets/6d59be74-c5de-4104-8077-eebdeddd20ad" alt="image of Adji Bousso Dieng" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Adji Bousso Dieng is an Assistant Professor of Computer Science at Princeton University where she leads the lab Vertaix on research at the intersection of artificial intelligence and the natural sciences. She is affiliated with the Chemical and Biological Engineering Department, the Princeton Materials Institute, the Princeton Quantum Initiative, the Andlinger Center for Energy and the Environment, and the High Meadows Environmental Institute (HMEI) at Princeton. She is also a Research Scientist at Google AI and the founder and President of the nonprofit The Africa I Know. She has been recently named an Early-Career Distinguished Presenter at the MRS Spring Meeting,  one of 10 African Scholars to watch in 2025 by The Africa Report, an Outstanding Recent Alumni by Columbia University's Grad School of Arts and Sciences, an AI2050 Early Career Fellow by Schmidt Sciences, and as the Annie T. Randall Innovator of 2022 for her research and advocacy by the American Statistical Association. She received her Ph.D. from Columbia University. Her doctoral work received many recognitions, including a Google Ph.D. Fellowship in Machine Learning, a rising star in Machine Learning nomination by the University of Maryland, and a Savage Award from the International Society for Bayesian Analysis, for her doctoral thesis. Dieng's research has been covered in media such as the New Scientist and TechXplore. She hails from Kaolack, Senegal. </p>
+            <p><b>Abstract:</b> This talk will cover the concepts, tools, and methods that make up Vendi Scoring, a new research direction focused on the concept of diversity. I’ll begin by introducing the Vendi Scores, a family of diversity metrics rooted in ecology and quantum mechanics, along with their extensions. Next, I’ll discuss algorithms for efficiently searching large materials databases and exploring complex energy landscapes, such as those found in molecular simulations, using the Vendi Scores. Finally, I’ll introduce the new concept of 'algorithmic microscopy,' which stems from Vendi Scoring, and describe the Vendiscope, the first algorithmic microscope designed to help scientists zoom in on large data collections for data-driven discovery.</p>
+        </details></p>
+    <p><b>12:10 - 12:30pm</b>: Contributed Talk&mdash;<b>TBD</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p>TBD</p>
+        </details></p>
+    <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
+    <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
+    <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
+    <p><b>2:50 - 3:30pm</b>: Gravitational Waves Talk</p>
+    <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
+    <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
+    <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
+    <p><b>5:00 - 5:30pm</b>: Closing Remarks and Discussion of Next Challenge</p>
+    </div>
 
-            <hr>
-            <div id="schedule">
-                <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
-                <p><b>9:10 - 9:45am</b>: Eric Nalisnick&mdash;<b>Anomalous Anomalies: Monitoring and Adapting Anomaly
-                        Detectors</b>
-                <details name="speaker-info">
-                    <summary>Details</summary>
-                    <div class="speaker-container">
-                        <!-- Bio heading on its own line -->
-                        <p class="speaker-bio-heading"><b>Bio:</b></p>
-                        <!-- Flex container for image and bio text -->
-                        <div class="speaker-details">
-                            <div class="speaker-image">
-                                <img src="https://github.com/enalisnick/enalisnick.github.io/blob/master/Nalisnick_Headshot.jpeg?raw=true"
-                                    alt="image of Eric Nalisnick">
-                            </div>
-                            <div class="speaker-text">
-                                <p>
-                                    Eric Nalisnick is an assistant professor at Johns Hopkins University. His research
-                                    interests
-                                    span statistical machine learning and probabilistic modeling, with an emphasis on
-                                    quantifying uncertainty in deep learning, human-AI collaboration, specifying prior
-                                    knowledge, and detecting distribution shift. He previously was an assistant
-                                    professor at the
-                                    University of Amsterdam, a postdoctoral researcher at the University of Cambridge
-                                    and a PhD
-                                    student at the University of California, Irvine. Eric has also held research
-                                    positions at
-                                    DeepMind, Microsoft, Twitter, and Amazon. His papers have been recognized with
-                                    selective
-                                    oral presentations (ECCV 2024) and awards (AIStats 2023, AIStats 2024).
-                                </p>
-                            </div>
-                        </div>
-                        <p>
-                            <b>Abstract:</b> Anomaly detectors perform essential tasks ranging from protecting an
-                            autonomous system from abnormal inputs to isolating interesting scientific signals that
-                            may lead to discovery. However, how do we know that the anomaly detector will be robust?
-                            The detector itself could be susceptible to failure if there is a change in the
-                            distribution of anomalies expected. And to make matters worse, we usually don't have an
-                            abundance of test-time anomalies that are labeled as such. In this talk, I will discuss
-                            my group's recent work on monitoring if our anomaly detector is still valid and adapting
-                            it to data shift, without supervision.
-                        </p>
-                    </div>
-                </details>
-                </p>
-                <p><b>9:45 - 10:20am</b>: Jennifer Ngadiuba&mdash;<b>Boosting sensitivity to new physics at the LHC with
-                        anomaly detection</b>
-                <details name="speaker-info">
-                    <summary>Details</summary>
-                    <div class="speaker-container">
-                        <!-- Bio heading on its own line -->
-                        <p class="speaker-bio-heading"><b>Bio:</b></p>
-                        <!-- Flex container for image and bio text -->
-                        <div class="speaker-details">
-                            <div class="speaker-image">
-                                <img src="https://github.com/user-attachments/assets/5e2532ee-0090-4725-8bb8-58cee458e3ea"
-                                    alt="image of Jennifer Ngadiuba">
-                            </div>
-                            <div class="speaker-text">
-                                <p>
-                                    Jennifer Ngadiuba, a Wilson Fellow at Fermilab since 2021, specializes in searching
-                                    for new physics in collider data and advancing AI applications in high-energy
-                                    physics. After
-                                    earning her Ph.D. from the University of Zurich, she contributed to CMS experiment
-                                    studies,
-                                    focusing on diboson resonances and jet substructure techniques. Starting when she
-                                    was research
-                                    fellow at CERN and Caltech, she pioneered deep learning for anomaly detection and
-                                    fast machine
-                                    learning on FPGAs for real-time systems in particle physics. Her work earned her the
-                                    DOE AI4HEP
-                                    award and AI2050 fellowship in 2023, recognizing her transformative contributions to
-                                    experimental physics and machine learning.
-                                </p>
-                            </div>
-                        </div>
-                        <p>
-                            <b>Abstract:</b> Anomaly detection techniques have been proposed as a way to mitigate the
-                            impact
-                            of
-                            model-specific assumptions when searching for new physics at the LHC. In this talk I will
-                            discuss how these techniques, when based on modern AI developments, could be utilized
-                            at different stages of data processing workflow, from real-time systems to offline analysis,
-                            and the impact they could have to revolutionize the current paradigms in the search for
-                            new physics.
-                        </p>
-                    </div>
-                </details>
-                </p>
-                <p><b>10:30 - 11:30am</b>: Coffee Break and Poster Session (<a href="#papers-posters">Papers and
-                        Associated Posters</a>)</p>
-                <p><b>11:30 - 12:10pm</b>: Adji Bousso Dieng&mdash;<b>Vendi Scoring For Discovery</b>
-                <details name="speaker-info">
-                    <summary>Details</summary>
-                    <div class="speaker-container">
-                        <!-- Bio heading on its own line -->
-                        <p class="speaker-bio-heading"><b>Bio:</b></p>
-                        <!-- Flex container for image and bio text -->
-                        <div class="speaker-details">
-                            <div class="speaker-image">
-                                <img src="https://github.com/user-attachments/assets/6d59be74-c5de-4104-8077-eebdeddd20ad"
-                                    alt="image of Adji Bousso Dieng">
-                            </div>
-                            <div class="speaker-text">
-                                <p>
-                                    Adji Bousso Dieng is an Assistant Professor of Computer Science at Princeton
-                                    University where she leads the lab Vertaix on research at the intersection of
-                                    artificial
-                                    intelligence and the natural sciences. She is affiliated with the Chemical
-                                    and Biological
-                                    Engineering Department, the Princeton Materials Institute, the Princeton Quantum
-                                    Initiative, the
-                                    Andlinger Center for Energy and the Environment, and the High Meadows Environmental
-                                    Institute
-                                    (HMEI) at Princeton. She is also a Research Scientist at Google AI and the founder
-                                    and President
-                                    of the nonprofit The Africa I Know. She has been recently named an Early-Career
-                                    Distinguished
-                                    Presenter at the MRS Spring Meeting,  one of 10 African Scholars to watch in 2025 by
-                                    The Africa
-                                    Report, an Outstanding Recent Alumni by Columbia University's Grad School of Arts
-                                    and Sciences,
-                                    an AI2050 Early Career Fellow by Schmidt Sciences, and as the Annie T. Randall
-                                    Innovator of
-                                    2022 for her research and advocacy by the American Statistical Association. She
-                                    received her
-                                    Ph.D. from Columbia University. Her doctoral work received many recognitions,
-                                    including a Google
-                                    Ph.D. Fellowship in Machine Learning, a rising star in Machine Learning nomination
-                                    by the
-                                    University of Maryland, and a Savage Award from the International
-                                    Society for Bayesian
-                                    Analysis, for her doctoral thesis. Dieng's research has been covered in media such
-                                    as the New
-                                    Scientist and TechXplore. She hails from Kaolack, Senegal. 
-                                </p>
-                            </div>
-                        </div>
-                        <p>
-                            <b>Abstract:</b> This talk will cover the concepts, tools, and methods that make up Vendi
-                            Scoring, a new research direction focused on the concept of diversity. I’ll begin by
-                            introducing
-                            the Vendi Scores, a family of diversity metrics rooted in ecology and quantum mechanics,
-                            along
-                            with their extensions. Next, I’ll discuss algorithms for efficiently searching large
-                            materials
-                            databases and exploring complex energy landscapes, such as those found in molecular
-                            simulations,
-                            using the Vendi Scores. Finally, I’ll introduce the new concept of 'algorithmic microscopy,'
-                            which stems from Vendi Scoring, and describe the Vendiscope, the first algorithmic
-                            microscope
-                            designed to help scientists zoom in on large data collections for data-driven discovery.
-                        </p>
-                    </div>
-                </details>
-                </p>
-                <p><b>12:10 - 12:30pm</b>: Contributed Talk&mdash;<b>TBD</b>
-                <details name="speaker-info">
-                    <summary>Details</summary>
-                    <p>TBD</p>
-                </details>
-                </p>
-                <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
-                <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
-                <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
-                <p><b>2:50 - 3:30pm</b>: Gravitational Waves Talk</p>
-                <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
-                <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
-                <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
-                <p><b>5:00 - 5:30pm</b>: Closing Remarks and Discussion of Next Challenge</p>
-            </div>
+    <hr>
 
-            <hr>
+    <div style="color:#6a1b9a" id="papers-posters">
+        <h1>Accepted Papers</h1>
+</div>
+<hr>
+<ol>
+    <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/10xYrwNGfpKn_P6FMHdFPgP8nYmEQVFYK/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D. Le </li>
+    <br>
+    <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1L977sDPKmBZsDVBwpziW6toM_Ndvp9B1/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit Sheth</li>
+    <br>
+    <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
+    <br>
+    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1fhoFTPF-PpOKFhAO3MT25E6eiVd1pjU2/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
+    <br>
+    <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
+    <br>
+    <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1p6gUc-v5o606FJLCL3sPbNWcNcuspdAk/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
+    <br>
+    <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1VFW5IUuD-t9NozOBgakUblbPdr0iJkAd/view?usp=drive_link" target="_blank">Poster</a>]<br>
+        Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
+    </ol>
 
-            <div style="color:#6a1b9a" id="papers-posters">
-                <h1>Accepted Papers</h1>
-            </div>
-            <hr>
-            <ol>
-                <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a
-                        href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/10xYrwNGfpKn_P6FMHdFPgP8nYmEQVFYK/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D.
-                    Le </li>
-                <br>
-                <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a
-                        href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/1L977sDPKmBZsDVBwpziW6toM_Ndvp9B1/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit
-                    Sheth</li>
-                <br>
-                <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a
-                        href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
-                <br>
-                <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a
-                        href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/1fhoFTPF-PpOKFhAO3MT25E6eiVd1pjU2/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
-                <br>
-                <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a
-                        href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
-                <br>
-                <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a
-                        href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/1p6gUc-v5o606FJLCL3sPbNWcNcuspdAk/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
-                <br>
-                <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a
-                        href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link"
-                        target="_blank">PDF</a>] [<a
-                        href="https://drive.google.com/file/d/1VFW5IUuD-t9NozOBgakUblbPdr0iJkAd/view?usp=drive_link"
-                        target="_blank">Poster</a>]<br>
-                    Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
-            </ol>
+        <hr>
 
-            <hr>
+        <div style="color:#6a1b9a">
+            <h1>Call for Challenge Participation</h1>
+    </div>
 
-            <div style="color:#6a1b9a">
-                <h1>Call for Challenge Participation</h1>
-            </div>
+    <hr>
 
-            <hr>
-
-            <h3>The ML Challenge is extended to run through January 31st, 2025!</h3>
-
-            <!-- Embed the video below this section -->
-            <div class="video-container">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un"
-                    title="YouTube video player" frameborder="0"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-            </div>
-
+        <h3>The ML Challenge is extended to run through January 31st, 2025!</h3>
+    
+        <!-- Embed the video below this section -->
+    <div class="video-container">
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>    </div>
+        
             <div class="hero-button">
                 <a href="rules.html" target="_blank">Participate in the Anomaly Detection challenge</a>
             </div>
-
+        
             <div class="image-row">
                 <a href="https://www.codabench.org/competitions/3764/" target="_blank" class="circle" id="circle1">
                     <img src="images/butterfly.jpg" alt="Butterfly">
@@ -336,32 +156,28 @@
                 <a href="https://www.codabench.org/competitions/3223" target="_blank" class="circle" id="circle3">
                     <img src="images/water_levels.jpg" alt="Water Levels">
                     <div class="hover-text" id="hover-text3">
-                        Identifying unusual fluctuations in water levels that do not correspond to known environmental
-                        factors or historical data patterns
+                        Identifying unusual fluctuations in water levels that do not correspond to known environmental factors or historical data patterns
                     </div>
                 </a>
             </div>
             <br>
-            <hr>
+    <hr>
             <div style="color:#6a1b9a">
                 <h1>Call for Paper Submission</h1>
-            </div>
-            <hr>
+        </div>
+    <hr>
 
-            <h2>Topics</h2>
-            <p>
-                We encourage participation from researchers in a broad range of topics that explore AI/ML techniques to
-                detect novel patterns and anomalies within data and promote scientific discovery. Examples of research
-                questions include (but are not limited to):
+        <h2>Topics</h2>
+        <p>
+            We encourage participation from researchers in a broad range of topics that explore AI/ML techniques to detect novel patterns and anomalies within data and promote scientific discovery. Examples of research questions include (but are not limited to): 
             <ol>
                 <li>How can we automate the discovery of new scientific phenomena?</li>
-                <li>How can we embed a notion of uncertainty within AI/ML to quantify the significance of a discovery?
-                </li>
+                <li>How can we embed a notion of uncertainty within AI/ML to quantify the significance of a discovery?</li>
                 <li>How do we ensure FAIR reproducibility of these discoveries?</li>
-                <li>What interpretable AI/ML approaches can lead to direct explanations of these discoveries?</li>
+                <li>What interpretable AI/ML approaches can lead to direct explanations of these discoveries?</li>  
             </ol>
-            </p>
-            <h2>Key Dates</h2>
+        </p>
+        <h2>Key Dates</h2>
             <ul>
                 <li>Paper Submission Deadline: December 6, 2024. 11:59 PM AOE</li>
                 <li>Acceptance/Rejection Decision: December 16, 2024</li>
@@ -371,60 +187,52 @@
                 <li>Workshop Date: March 4, 2025</li>
             </ul>
             <p>
-                <small>We offer an extended deadline for submissions with the same Camera-Ready and Poster Deadlines,
-                    but keep in mind that these are <i><b>after</b></i> the AAAI Early Registration Deadline has
-                    passed.</small>
+                <small>We offer an extended deadline for submissions with the same Camera-Ready and Poster Deadlines, but keep in mind that these are <i><b>after</b></i> the AAAI Early Registration Deadline has passed.</small>
             </p>
             <ul>
                 <li>Paper Submission Deadline: January 31, 2025. 11:59 PM AOE</li>
                 <li>Acceptance/Rejection Decision: February 7, 2025</li>
             </ul>
-            <h2>Submission Requirements</h2>
-            <p>
-                We are accepting extended abstract submissions for position, review, or research results (up to 2 pages,
-                excluding references). Shorter versions (up to 6 pages, excluding references) of articles in submission
-                or accepted at other venues (or presented after Oct. 1, 2024) are acceptable as long as they do not
-                violate the dual-submission policy of the other venue. We allow the addition of an appendix (no page
-                limit) following references. All submissions will undergo peer review (double-blind).
-            </p>
-            <p>
-                Submissions should follow the AAAI template format (two-column, camera-ready style; <a
-                    href="https://aaai.org/authorkit25/" target="_blank">AAAI Author Kit</a>) and submitted via CMT.
-            </p>
-            <p>
-                <i>The accepted paper will <b>NOT</b> be archived in AAAI proceedings. This allows the authors to extend
-                    their work afterward and submit it to a conference or journal.</i>
-            </p>
-            <div class="hero-button">
-                <a href="https://cmt3.research.microsoft.com/HDRAnomaly2025" target="_blank">Submit Your Work Today!</a>
-            </div>
-            <h2>Organizing Committee</h2>
-            <ul>
-                <li>
-                    Wei-Lun Chao (The Ohio State University, chao.209@osu.edu, primary contact)
-                </li>
-                <li>
-                    Philip Harris (Massachusetts Institute of Technology, pcharris@mit.edu)
-                </li>
-                <li>
-                    Elizabeth G. Campolongo (The Ohio State University, campolongo.4@osu.edu)
-                </li>
-                <li>
-                    Yuan-Tang Chou (University of Washington, ytchou@uw.edu)
-                </li>
-                <li>
-                    Katya Govorkova (Massachusetts Institute of Technology, katyag@mit.edu)
-                </li>
-                <li>
-                    Hilmar Lapp (Duke University, hilmar.lapp@duke.edu)
-                </li>
-                <li>
-                    Josephine Namayanja (University of Maryland, Baltimore County, jona1@umbc.edu)
-                </li>
-                <li>
-                    Aneesh Subramanian (University of Colorado Boulder, aneeshcs@colorado.edu)
-                </li>
-            </ul>
+        <h2>Submission Requirements</h2>
+        <p>
+            We are accepting extended abstract submissions for position, review, or research results (up to 2 pages, excluding references). Shorter versions (up to 6 pages, excluding references) of articles in submission or accepted at other venues (or presented after Oct. 1, 2024) are acceptable as long as they do not violate the dual-submission policy of the other venue. We allow the addition of an appendix (no page limit) following references. All submissions will undergo peer review (double-blind).
+        </p>
+        <p>
+            Submissions should follow the AAAI template format (two-column, camera-ready style; <a href="https://aaai.org/authorkit25/" target="_blank">AAAI Author Kit</a>) and submitted via CMT.
+        </p>
+        <p>
+            <i>The accepted paper will <b>NOT</b> be archived in AAAI proceedings. This allows the authors to extend their work afterward and submit it to a conference or journal.</i>
+        </p>
+        <div class="hero-button">
+            <a href="https://cmt3.research.microsoft.com/HDRAnomaly2025" target="_blank">Submit Your Work Today!</a>
+        </div>
+        <h2>Organizing Committee</h2>
+        <ul>
+            <li>
+                Wei-Lun Chao (The Ohio State University, chao.209@osu.edu, primary contact)
+            </li>
+            <li>
+                Philip Harris (Massachusetts Institute of Technology, pcharris@mit.edu)
+            </li>
+            <li>
+                Elizabeth G. Campolongo (The Ohio State University, campolongo.4@osu.edu)
+            </li>
+            <li>
+                Yuan-Tang Chou (University of Washington, ytchou@uw.edu)
+            </li>
+            <li>
+                Katya Govorkova (Massachusetts Institute of Technology, katyag@mit.edu)
+            </li>
+            <li>
+                Hilmar Lapp (Duke University, hilmar.lapp@duke.edu)
+            </li>
+            <li>
+                Josephine Namayanja (University of Maryland, Baltimore County, jona1@umbc.edu)
+            </li>
+            <li>
+                Aneesh Subramanian (University of Colorado Boulder, aneeshcs@colorado.edu)
+            </li>
+        </ul>
         </div>
     </section>
 
@@ -446,5 +254,4 @@
     </script>
 
 </body>
-
 </html>

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -42,6 +42,35 @@
             The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
         </p>
 
+    <hr>
+
+    <div style="color:#6a1b9a">
+        <h1>Accepted Papers</h1>
+</div>
+<hr>
+<ol>
+    <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D. Le </li>
+    <br>
+    <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit Sheth</li>
+    <br>
+    <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
+    <br>
+    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
+    <br>
+    <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
+    <br>
+    <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
+    <br>
+    <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link" target="_blank">PDF</a>] <br>
+        Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
+    </ol>
+
         <hr>
 
         <div style="color:#6a1b9a">

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -109,7 +109,7 @@
     <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
     <br>
-    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] [<a href="" target="_blank">Poster</a>]<br>
+    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1fhoFTPF-PpOKFhAO3MT25E6eiVd1pjU2/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
     <br>
     <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link" target="_blank">Poster</a>]<br>

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -44,6 +44,32 @@
 
         <hr>
 
+        <div style="color:#6a1b9a">
+            <h1>Workshop Program</h1>
+    </div>
+
+    <hr>
+        
+    <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
+    <p><b>9:10 - 9:45am</b>: Talk 1</p>
+    <p><b>9:45 - 10:20am</b>: Talk 2</p>
+    <p><b>10:30 - 11:00am</b>: Coffee Break</p>
+    <p><b>11:00 - 11:20am</b>: Poster Session (<a href="#papers-posters">Papers and Associated Posters</a>)</p>
+    <p><b>11:20 - 11:35am</b>: Contributed Talk</p>
+    <p><b>11:35 - 11:50am</b>: Contributed Talk</p>
+    <p><b>11:50 - 12:30pm</b>: Talk 3</p>
+    <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
+    <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
+    <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
+    <p><b>2:50 - 3:30pm</b>: Gravitational Waves Talk</p>
+    <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
+    <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
+    <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
+    <p><b>5:00 - 5:30pm</b>: Closing Remarks</p>
+
+
+    <hr>
+
     <div style="color:#6a1b9a" id="papers-posters">
         <h1>Accepted Papers</h1>
 </div>

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,11 +9,14 @@
     <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&display=swap" rel="stylesheet">
     <style>
         .video-container {
-            margin-top: 20px; /* Adjust the value to control the space between button and video */
-            text-align: center; /* Optional: Center the video */
+            margin-top: 20px;
+            /* Adjust the value to control the space between button and video */
+            text-align: center;
+            /* Optional: Center the video */
         }
     </style>
 </head>
+
 <body>
 
     <div id="header"></div>
@@ -20,126 +24,302 @@
     <section class="hero">
         <div id="logo"></div>
         <div class="hero-content" id="workshop-content">
-        <h1>Anomaly Detection in Scientific Domains AAAI Workshop</h1> 
+            <h1>Anomaly Detection in Scientific Domains AAAI Workshop</h1>
             <h3>Tuesday, March 4, 2025 from 9am to 6pm</h3>
             <h3>Philadeliphia, PA, USA</h3>
-        <h2>Description</h2>
-        <p>
-            Scientific discovery often involves the observation of an inconsistency among “normal” patterns within our data. The observation of something different, incongruous with the data, is what we call anomaly detection. 
-            Looking for anomalies is quite different from other tasks since we do not know what exactly to look for—we just need to look for something different. The goal of this workshop is to nurture the community of researchers working at the intersection of machine learning and various scientific domains toward scientific discovery. 
-        </p>
-        <p>
-            This workshop will also serve as the award ceremony with special recognition of the winners for the <a href="https://www.nsfhdr.org/mlchallenge" target="_blank">1st HDR Interdisciplinary Machine Learning Challenge</a> focusing on anomaly detection. 
-            The challenge is a series of 4 challenges one for each of three distinct scientific domains (biology, physics, and climate science), and a combined challenge across domains. A critical element of this challenge was the integration of FAIR and Reproducible science. 
-        </p>
-       
-        <h2>Format</h2>
-        <p>
-            Our 1-day workshop will include keynote/invited talks, contributed paper presentations, a poster session, a panel discussion, and winning team presentations of their solutions to the challenge.
-        </p>
-        <h2>Attendance</h2>
-        <p>
-            The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
-        </p>
+            <h2>Description</h2>
+            <p>
+                Scientific discovery often involves the observation of an inconsistency among “normal” patterns within
+                our data. The observation of something different, incongruous with the data, is what we call anomaly
+                detection.
+                Looking for anomalies is quite different from other tasks since we do not know what exactly to look
+                for—we just need to look for something different. The goal of this workshop is to nurture the community
+                of researchers working at the intersection of machine learning and various scientific domains toward
+                scientific discovery.
+            </p>
+            <p>
+                This workshop will also serve as the award ceremony with special recognition of the winners for the <a
+                    href="https://www.nsfhdr.org/mlchallenge" target="_blank">1st HDR Interdisciplinary Machine Learning
+                    Challenge</a> focusing on anomaly detection.
+                The challenge is a series of 4 challenges one for each of three distinct scientific domains (biology,
+                physics, and climate science), and a combined challenge across domains. A critical element of this
+                challenge was the integration of FAIR and Reproducible science.
+            </p>
 
-        <hr>
+            <h2>Format</h2>
+            <p>
+                Our 1-day workshop will include keynote/invited talks, contributed paper presentations, a poster
+                session, a panel discussion, and winning team presentations of their solutions to the challenge.
+            </p>
+            <h2>Attendance</h2>
+            <p>
+                The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics
+                such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific
+                discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary
+                research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
+            </p>
 
-        <div style="color:#6a1b9a">
-            <h1>Workshop Program</h1>
-    </div>
+            <hr>
 
-    <hr>
-    <div id="schedule">
-    <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
-    <p><b>9:10 - 9:45am</b>: Eric Nalisnick&mdash;<b>Anomalous Anomalies: Monitoring and Adapting Anomaly Detectors</b>
-        <details name="speaker-info">
-            <summary>Details</summary>
-            <p><img src="https://github.com/enalisnick/enalisnick.github.io/blob/master/Nalisnick_Headshot.jpeg?raw=true" alt="image of Eric Nalisnick" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
-            <b>Bio:</b> Eric Nalisnick is an assistant professor at Johns Hopkins University. His research interests span statistical machine learning and probabilistic modeling, with an emphasis on quantifying uncertainty in deep learning, human-AI collaboration, specifying prior knowledge, and detecting distribution shift. He previously was an assistant professor at the University of Amsterdam, a postdoctoral researcher at the University of Cambridge and a PhD student at the University of California, Irvine. Eric has also held research positions at DeepMind, Microsoft, Twitter, and Amazon. His papers have been recognized with selective oral presentations (ECCV 2024) and awards (AIStats 2023, AIStats 2024).</p>
-            <p><b>Abstract:</b> Anomaly detectors perform essential tasks ranging from protecting an autonomous system from abnormal inputs to isolating interesting scientific signals that may lead to discovery.  However, how do we know that the anomaly detector will be robust?  The detector itself could be susceptible to failure if there is a change in the distribution of anomalies expected.  And to make matters worse, we usually don't have an abundance of test-time anomalies that are labeled as such.  In this talk, I will discuss my group's recent work on monitoring if our anomaly detector is still valid and adapting it to data shift, without supervision.</p>
-        </details></p>
-    <p><b>9:45 - 10:20am</b>: Jennifer Ngadiuba&mdash;<b>Boosting sensitivity to new physics at the LHC with anomaly detection</b>
-        <details name="speaker-info">
-            <summary>Details</summary>
-            <p><img src="https://github.com/user-attachments/assets/5e2532ee-0090-4725-8bb8-58cee458e3ea" alt="image of Jennifer Ngadiuba" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
-            <b>Bio:</b> Jennifer Ngadiuba, a Wilson Fellow at Fermilab since 2021, specializes in searching for new physics in collider data and advancing AI applications in high-energy physics. After earning her Ph.D. from the University of Zurich, she contributed to CMS experiment studies, focusing on diboson resonances and jet substructure techniques. Starting when she was research fellow at CERN and Caltech, she pioneered deep learning for anomaly detection and fast machine learning on FPGAs for real-time systems in particle physics. Her work earned her the DOE AI4HEP award and AI2050 fellowship in 2023, recognizing her transformative contributions to experimental physics and machine learning.</p>
-            <p><b>Abstract:</b> Anomaly detection techniques have been proposed as a way to mitigate the impact of
-                model-specific assumptions when searching for new physics at the LHC. In this talk I will
-                discuss how these techniques, when based on modern AI developments, could be utilized
-                at different stages of data processing workflow, from real-time systems to offline analysis,
-                and the impact they could have to revolutionize the current paradigms in the search for
-                new physics.</p>
-        </details></p>
-    <p><b>10:30 - 11:30am</b>: Coffee Break and Poster Session (<a href="#papers-posters">Papers and Associated Posters</a>)</p>
-    <p><b>11:30 - 12:10pm</b>: Adji Bousso Dieng&mdash;<b>Vendi Scoring For Discovery</b>
-        <details name="speaker-info">
-            <summary>Details</summary>
-            <p><img src="https://github.com/user-attachments/assets/6d59be74-c5de-4104-8077-eebdeddd20ad" alt="image of Adji Bousso Dieng" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
-            <b>Bio:</b> Adji Bousso Dieng is an Assistant Professor of Computer Science at Princeton University where she leads the lab Vertaix on research at the intersection of artificial intelligence and the natural sciences. She is affiliated with the Chemical and Biological Engineering Department, the Princeton Materials Institute, the Princeton Quantum Initiative, the Andlinger Center for Energy and the Environment, and the High Meadows Environmental Institute (HMEI) at Princeton. She is also a Research Scientist at Google AI and the founder and President of the nonprofit The Africa I Know. She has been recently named an Early-Career Distinguished Presenter at the MRS Spring Meeting,  one of 10 African Scholars to watch in 2025 by The Africa Report, an Outstanding Recent Alumni by Columbia University's Grad School of Arts and Sciences, an AI2050 Early Career Fellow by Schmidt Sciences, and as the Annie T. Randall Innovator of 2022 for her research and advocacy by the American Statistical Association. She received her Ph.D. from Columbia University. Her doctoral work received many recognitions, including a Google Ph.D. Fellowship in Machine Learning, a rising star in Machine Learning nomination by the University of Maryland, and a Savage Award from the International Society for Bayesian Analysis, for her doctoral thesis. Dieng's research has been covered in media such as the New Scientist and TechXplore. She hails from Kaolack, Senegal. </p>
-            <p><b>Abstract:</b> This talk will cover the concepts, tools, and methods that make up Vendi Scoring, a new research direction focused on the concept of diversity. I’ll begin by introducing the Vendi Scores, a family of diversity metrics rooted in ecology and quantum mechanics, along with their extensions. Next, I’ll discuss algorithms for efficiently searching large materials databases and exploring complex energy landscapes, such as those found in molecular simulations, using the Vendi Scores. Finally, I’ll introduce the new concept of 'algorithmic microscopy,' which stems from Vendi Scoring, and describe the Vendiscope, the first algorithmic microscope designed to help scientists zoom in on large data collections for data-driven discovery.</p>
-        </details></p>
-    <p><b>12:10 - 12:30pm</b>: Contributed Talk&mdash;<b>TBD</b>
-        <details name="speaker-info">
-            <summary>Details</summary>
-            <p>TBD</p>
-        </details></p>
-    <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
-    <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
-    <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
-    <p><b>2:50 - 3:30pm</b>: Gravitational Waves Talk</p>
-    <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
-    <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
-    <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
-    <p><b>5:00 - 5:30pm</b>: Closing Remarks and Discussion of Next Challenge</p>
-    </div>
+            <div style="color:#6a1b9a">
+                <h1>Workshop Program</h1>
+            </div>
 
-    <hr>
+            <hr>
+            <div id="schedule">
+                <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
+                <p><b>9:10 - 9:45am</b>: Eric Nalisnick&mdash;<b>Anomalous Anomalies: Monitoring and Adapting Anomaly
+                        Detectors</b>
+                <details name="speaker-info">
+                    <summary>Details</summary>
+                    <div class="speaker-container">
+                        <!-- Bio heading on its own line -->
+                        <p class="speaker-bio-heading"><b>Bio:</b></p>
+                        <!-- Flex container for image and bio text -->
+                        <div class="speaker-details">
+                            <div class="speaker-image">
+                                <img src="https://github.com/enalisnick/enalisnick.github.io/blob/master/Nalisnick_Headshot.jpeg?raw=true"
+                                    alt="image of Eric Nalisnick">
+                            </div>
+                            <div class="speaker-text">
+                                <p>
+                                    Eric Nalisnick is an assistant professor at Johns Hopkins University. His research
+                                    interests
+                                    span statistical machine learning and probabilistic modeling, with an emphasis on
+                                    quantifying uncertainty in deep learning, human-AI collaboration, specifying prior
+                                    knowledge, and detecting distribution shift. He previously was an assistant
+                                    professor at the
+                                    University of Amsterdam, a postdoctoral researcher at the University of Cambridge
+                                    and a PhD
+                                    student at the University of California, Irvine. Eric has also held research
+                                    positions at
+                                    DeepMind, Microsoft, Twitter, and Amazon. His papers have been recognized with
+                                    selective
+                                    oral presentations (ECCV 2024) and awards (AIStats 2023, AIStats 2024).
+                                </p>
+                            </div>
+                        </div>
+                        <p>
+                            <b>Abstract:</b> Anomaly detectors perform essential tasks ranging from protecting an
+                            autonomous system from abnormal inputs to isolating interesting scientific signals that
+                            may lead to discovery. However, how do we know that the anomaly detector will be robust?
+                            The detector itself could be susceptible to failure if there is a change in the
+                            distribution of anomalies expected. And to make matters worse, we usually don't have an
+                            abundance of test-time anomalies that are labeled as such. In this talk, I will discuss
+                            my group's recent work on monitoring if our anomaly detector is still valid and adapting
+                            it to data shift, without supervision.
+                        </p>
+                    </div>
+                </details>
+                </p>
+                <p><b>9:45 - 10:20am</b>: Jennifer Ngadiuba&mdash;<b>Boosting sensitivity to new physics at the LHC with
+                        anomaly detection</b>
+                <details name="speaker-info">
+                    <summary>Details</summary>
+                    <div class="speaker-container">
+                        <!-- Bio heading on its own line -->
+                        <p class="speaker-bio-heading"><b>Bio:</b></p>
+                        <!-- Flex container for image and bio text -->
+                        <div class="speaker-details">
+                            <div class="speaker-image">
+                                <img src="https://github.com/user-attachments/assets/5e2532ee-0090-4725-8bb8-58cee458e3ea"
+                                    alt="image of Jennifer Ngadiuba">
+                            </div>
+                            <div class="speaker-text">
+                                <p>
+                                    Jennifer Ngadiuba, a Wilson Fellow at Fermilab since 2021, specializes in searching
+                                    for new physics in collider data and advancing AI applications in high-energy
+                                    physics. After
+                                    earning her Ph.D. from the University of Zurich, she contributed to CMS experiment
+                                    studies,
+                                    focusing on diboson resonances and jet substructure techniques. Starting when she
+                                    was research
+                                    fellow at CERN and Caltech, she pioneered deep learning for anomaly detection and
+                                    fast machine
+                                    learning on FPGAs for real-time systems in particle physics. Her work earned her the
+                                    DOE AI4HEP
+                                    award and AI2050 fellowship in 2023, recognizing her transformative contributions to
+                                    experimental physics and machine learning.
+                                </p>
+                            </div>
+                        </div>
+                        <p>
+                            <b>Abstract:</b> Anomaly detection techniques have been proposed as a way to mitigate the
+                            impact
+                            of
+                            model-specific assumptions when searching for new physics at the LHC. In this talk I will
+                            discuss how these techniques, when based on modern AI developments, could be utilized
+                            at different stages of data processing workflow, from real-time systems to offline analysis,
+                            and the impact they could have to revolutionize the current paradigms in the search for
+                            new physics.
+                        </p>
+                    </div>
+                </details>
+                </p>
+                <p><b>10:30 - 11:30am</b>: Coffee Break and Poster Session (<a href="#papers-posters">Papers and
+                        Associated Posters</a>)</p>
+                <p><b>11:30 - 12:10pm</b>: Adji Bousso Dieng&mdash;<b>Vendi Scoring For Discovery</b>
+                <details name="speaker-info">
+                    <summary>Details</summary>
+                    <div class="speaker-container">
+                        <!-- Bio heading on its own line -->
+                        <p class="speaker-bio-heading"><b>Bio:</b></p>
+                        <!-- Flex container for image and bio text -->
+                        <div class="speaker-details">
+                            <div class="speaker-image">
+                                <img src="https://github.com/user-attachments/assets/6d59be74-c5de-4104-8077-eebdeddd20ad"
+                                    alt="image of Adji Bousso Dieng">
+                            </div>
+                            <div class="speaker-text">
+                                <p>
+                                    Adji Bousso Dieng is an Assistant Professor of Computer Science at Princeton
+                                    University where she leads the lab Vertaix on research at the intersection of
+                                    artificial
+                                    intelligence and the natural sciences. She is affiliated with the Chemical
+                                    and Biological
+                                    Engineering Department, the Princeton Materials Institute, the Princeton Quantum
+                                    Initiative, the
+                                    Andlinger Center for Energy and the Environment, and the High Meadows Environmental
+                                    Institute
+                                    (HMEI) at Princeton. She is also a Research Scientist at Google AI and the founder
+                                    and President
+                                    of the nonprofit The Africa I Know. She has been recently named an Early-Career
+                                    Distinguished
+                                    Presenter at the MRS Spring Meeting,  one of 10 African Scholars to watch in 2025 by
+                                    The Africa
+                                    Report, an Outstanding Recent Alumni by Columbia University's Grad School of Arts
+                                    and Sciences,
+                                    an AI2050 Early Career Fellow by Schmidt Sciences, and as the Annie T. Randall
+                                    Innovator of
+                                    2022 for her research and advocacy by the American Statistical Association. She
+                                    received her
+                                    Ph.D. from Columbia University. Her doctoral work received many recognitions,
+                                    including a Google
+                                    Ph.D. Fellowship in Machine Learning, a rising star in Machine Learning nomination
+                                    by the
+                                    University of Maryland, and a Savage Award from the International
+                                    Society for Bayesian
+                                    Analysis, for her doctoral thesis. Dieng's research has been covered in media such
+                                    as the New
+                                    Scientist and TechXplore. She hails from Kaolack, Senegal. 
+                                </p>
+                            </div>
+                        </div>
+                        <p>
+                            <b>Abstract:</b> This talk will cover the concepts, tools, and methods that make up Vendi
+                            Scoring, a new research direction focused on the concept of diversity. I’ll begin by
+                            introducing
+                            the Vendi Scores, a family of diversity metrics rooted in ecology and quantum mechanics,
+                            along
+                            with their extensions. Next, I’ll discuss algorithms for efficiently searching large
+                            materials
+                            databases and exploring complex energy landscapes, such as those found in molecular
+                            simulations,
+                            using the Vendi Scores. Finally, I’ll introduce the new concept of 'algorithmic microscopy,'
+                            which stems from Vendi Scoring, and describe the Vendiscope, the first algorithmic
+                            microscope
+                            designed to help scientists zoom in on large data collections for data-driven discovery.
+                        </p>
+                    </div>
+                </details>
+                </p>
+                <p><b>12:10 - 12:30pm</b>: Contributed Talk&mdash;<b>TBD</b>
+                <details name="speaker-info">
+                    <summary>Details</summary>
+                    <p>TBD</p>
+                </details>
+                </p>
+                <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
+                <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
+                <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
+                <p><b>2:50 - 3:30pm</b>: Gravitational Waves Talk</p>
+                <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
+                <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
+                <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
+                <p><b>5:00 - 5:30pm</b>: Closing Remarks and Discussion of Next Challenge</p>
+            </div>
 
-    <div style="color:#6a1b9a" id="papers-posters">
-        <h1>Accepted Papers</h1>
-</div>
-<hr>
-<ol>
-    <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/10xYrwNGfpKn_P6FMHdFPgP8nYmEQVFYK/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D. Le </li>
-    <br>
-    <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1L977sDPKmBZsDVBwpziW6toM_Ndvp9B1/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit Sheth</li>
-    <br>
-    <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
-    <br>
-    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1fhoFTPF-PpOKFhAO3MT25E6eiVd1pjU2/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
-    <br>
-    <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
-    <br>
-    <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1p6gUc-v5o606FJLCL3sPbNWcNcuspdAk/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
-    <br>
-    <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1VFW5IUuD-t9NozOBgakUblbPdr0iJkAd/view?usp=drive_link" target="_blank">Poster</a>]<br>
-        Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
-    </ol>
+            <hr>
 
-        <hr>
+            <div style="color:#6a1b9a" id="papers-posters">
+                <h1>Accepted Papers</h1>
+            </div>
+            <hr>
+            <ol>
+                <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a
+                        href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/10xYrwNGfpKn_P6FMHdFPgP8nYmEQVFYK/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D.
+                    Le </li>
+                <br>
+                <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a
+                        href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/1L977sDPKmBZsDVBwpziW6toM_Ndvp9B1/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit
+                    Sheth</li>
+                <br>
+                <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a
+                        href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
+                <br>
+                <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a
+                        href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/1fhoFTPF-PpOKFhAO3MT25E6eiVd1pjU2/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
+                <br>
+                <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a
+                        href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
+                <br>
+                <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a
+                        href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/1p6gUc-v5o606FJLCL3sPbNWcNcuspdAk/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
+                <br>
+                <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a
+                        href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link"
+                        target="_blank">PDF</a>] [<a
+                        href="https://drive.google.com/file/d/1VFW5IUuD-t9NozOBgakUblbPdr0iJkAd/view?usp=drive_link"
+                        target="_blank">Poster</a>]<br>
+                    Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
+            </ol>
 
-        <div style="color:#6a1b9a">
-            <h1>Call for Challenge Participation</h1>
-    </div>
+            <hr>
 
-    <hr>
+            <div style="color:#6a1b9a">
+                <h1>Call for Challenge Participation</h1>
+            </div>
 
-        <h3>The ML Challenge is extended to run through January 31st, 2025!</h3>
-    
-        <!-- Embed the video below this section -->
-    <div class="video-container">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>    </div>
-        
+            <hr>
+
+            <h3>The ML Challenge is extended to run through January 31st, 2025!</h3>
+
+            <!-- Embed the video below this section -->
+            <div class="video-container">
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/6NNO0SVhL2c?si=z2LaTUYd46Hlp_un"
+                    title="YouTube video player" frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            </div>
+
             <div class="hero-button">
                 <a href="rules.html" target="_blank">Participate in the Anomaly Detection challenge</a>
             </div>
-        
+
             <div class="image-row">
                 <a href="https://www.codabench.org/competitions/3764/" target="_blank" class="circle" id="circle1">
                     <img src="images/butterfly.jpg" alt="Butterfly">
@@ -156,28 +336,32 @@
                 <a href="https://www.codabench.org/competitions/3223" target="_blank" class="circle" id="circle3">
                     <img src="images/water_levels.jpg" alt="Water Levels">
                     <div class="hover-text" id="hover-text3">
-                        Identifying unusual fluctuations in water levels that do not correspond to known environmental factors or historical data patterns
+                        Identifying unusual fluctuations in water levels that do not correspond to known environmental
+                        factors or historical data patterns
                     </div>
                 </a>
             </div>
             <br>
-    <hr>
+            <hr>
             <div style="color:#6a1b9a">
                 <h1>Call for Paper Submission</h1>
-        </div>
-    <hr>
+            </div>
+            <hr>
 
-        <h2>Topics</h2>
-        <p>
-            We encourage participation from researchers in a broad range of topics that explore AI/ML techniques to detect novel patterns and anomalies within data and promote scientific discovery. Examples of research questions include (but are not limited to): 
+            <h2>Topics</h2>
+            <p>
+                We encourage participation from researchers in a broad range of topics that explore AI/ML techniques to
+                detect novel patterns and anomalies within data and promote scientific discovery. Examples of research
+                questions include (but are not limited to):
             <ol>
                 <li>How can we automate the discovery of new scientific phenomena?</li>
-                <li>How can we embed a notion of uncertainty within AI/ML to quantify the significance of a discovery?</li>
+                <li>How can we embed a notion of uncertainty within AI/ML to quantify the significance of a discovery?
+                </li>
                 <li>How do we ensure FAIR reproducibility of these discoveries?</li>
-                <li>What interpretable AI/ML approaches can lead to direct explanations of these discoveries?</li>  
+                <li>What interpretable AI/ML approaches can lead to direct explanations of these discoveries?</li>
             </ol>
-        </p>
-        <h2>Key Dates</h2>
+            </p>
+            <h2>Key Dates</h2>
             <ul>
                 <li>Paper Submission Deadline: December 6, 2024. 11:59 PM AOE</li>
                 <li>Acceptance/Rejection Decision: December 16, 2024</li>
@@ -187,52 +371,60 @@
                 <li>Workshop Date: March 4, 2025</li>
             </ul>
             <p>
-                <small>We offer an extended deadline for submissions with the same Camera-Ready and Poster Deadlines, but keep in mind that these are <i><b>after</b></i> the AAAI Early Registration Deadline has passed.</small>
+                <small>We offer an extended deadline for submissions with the same Camera-Ready and Poster Deadlines,
+                    but keep in mind that these are <i><b>after</b></i> the AAAI Early Registration Deadline has
+                    passed.</small>
             </p>
             <ul>
                 <li>Paper Submission Deadline: January 31, 2025. 11:59 PM AOE</li>
                 <li>Acceptance/Rejection Decision: February 7, 2025</li>
             </ul>
-        <h2>Submission Requirements</h2>
-        <p>
-            We are accepting extended abstract submissions for position, review, or research results (up to 2 pages, excluding references). Shorter versions (up to 6 pages, excluding references) of articles in submission or accepted at other venues (or presented after Oct. 1, 2024) are acceptable as long as they do not violate the dual-submission policy of the other venue. We allow the addition of an appendix (no page limit) following references. All submissions will undergo peer review (double-blind).
-        </p>
-        <p>
-            Submissions should follow the AAAI template format (two-column, camera-ready style; <a href="https://aaai.org/authorkit25/" target="_blank">AAAI Author Kit</a>) and submitted via CMT.
-        </p>
-        <p>
-            <i>The accepted paper will <b>NOT</b> be archived in AAAI proceedings. This allows the authors to extend their work afterward and submit it to a conference or journal.</i>
-        </p>
-        <div class="hero-button">
-            <a href="https://cmt3.research.microsoft.com/HDRAnomaly2025" target="_blank">Submit Your Work Today!</a>
-        </div>
-        <h2>Organizing Committee</h2>
-        <ul>
-            <li>
-                Wei-Lun Chao (The Ohio State University, chao.209@osu.edu, primary contact)
-            </li>
-            <li>
-                Philip Harris (Massachusetts Institute of Technology, pcharris@mit.edu)
-            </li>
-            <li>
-                Elizabeth G. Campolongo (The Ohio State University, campolongo.4@osu.edu)
-            </li>
-            <li>
-                Yuan-Tang Chou (University of Washington, ytchou@uw.edu)
-            </li>
-            <li>
-                Katya Govorkova (Massachusetts Institute of Technology, katyag@mit.edu)
-            </li>
-            <li>
-                Hilmar Lapp (Duke University, hilmar.lapp@duke.edu)
-            </li>
-            <li>
-                Josephine Namayanja (University of Maryland, Baltimore County, jona1@umbc.edu)
-            </li>
-            <li>
-                Aneesh Subramanian (University of Colorado Boulder, aneeshcs@colorado.edu)
-            </li>
-        </ul>
+            <h2>Submission Requirements</h2>
+            <p>
+                We are accepting extended abstract submissions for position, review, or research results (up to 2 pages,
+                excluding references). Shorter versions (up to 6 pages, excluding references) of articles in submission
+                or accepted at other venues (or presented after Oct. 1, 2024) are acceptable as long as they do not
+                violate the dual-submission policy of the other venue. We allow the addition of an appendix (no page
+                limit) following references. All submissions will undergo peer review (double-blind).
+            </p>
+            <p>
+                Submissions should follow the AAAI template format (two-column, camera-ready style; <a
+                    href="https://aaai.org/authorkit25/" target="_blank">AAAI Author Kit</a>) and submitted via CMT.
+            </p>
+            <p>
+                <i>The accepted paper will <b>NOT</b> be archived in AAAI proceedings. This allows the authors to extend
+                    their work afterward and submit it to a conference or journal.</i>
+            </p>
+            <div class="hero-button">
+                <a href="https://cmt3.research.microsoft.com/HDRAnomaly2025" target="_blank">Submit Your Work Today!</a>
+            </div>
+            <h2>Organizing Committee</h2>
+            <ul>
+                <li>
+                    Wei-Lun Chao (The Ohio State University, chao.209@osu.edu, primary contact)
+                </li>
+                <li>
+                    Philip Harris (Massachusetts Institute of Technology, pcharris@mit.edu)
+                </li>
+                <li>
+                    Elizabeth G. Campolongo (The Ohio State University, campolongo.4@osu.edu)
+                </li>
+                <li>
+                    Yuan-Tang Chou (University of Washington, ytchou@uw.edu)
+                </li>
+                <li>
+                    Katya Govorkova (Massachusetts Institute of Technology, katyag@mit.edu)
+                </li>
+                <li>
+                    Hilmar Lapp (Duke University, hilmar.lapp@duke.edu)
+                </li>
+                <li>
+                    Josephine Namayanja (University of Maryland, Baltimore County, jona1@umbc.edu)
+                </li>
+                <li>
+                    Aneesh Subramanian (University of Colorado Boulder, aneeshcs@colorado.edu)
+                </li>
+            </ul>
         </div>
     </section>
 
@@ -254,4 +446,5 @@
     </script>
 
 </body>
+
 </html>

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -42,32 +42,32 @@
             The intended audience for this workshop includes (a) AI/ML/data science researchers working on topics such as anomaly and novelty detection, out-of-distribution detection, open world recognition, scientific discovery, and FAIR dataset and reproducible workflows, who are looking for novel interdisciplinary research problems; (b) domain scientists working on problems with data-driven scientific discoveries.
         </p>
 
-    <hr>
+        <hr>
 
-    <div style="color:#6a1b9a">
+    <div style="color:#6a1b9a" id="papers-posters">
         <h1>Accepted Papers</h1>
 </div>
 <hr>
 <ol>
-    <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Using Diffusion Inpainting Model to Recognize Out-of-distribution Objects</b> [<a href="https://drive.google.com/file/d/1HdBRiWOA22kkmnOZ_F8NhQgOKxX_jPTp/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/10xYrwNGfpKn_P6FMHdFPgP8nYmEQVFYK/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Quang-Huy Nguyen, Jin Peng Zhou, Zhenzhen Liu, Kilian Q. Weinberger, Wei-Lun Chao, Dung D. Le </li>
     <br>
-    <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Time Series Foundational Models: Their Role in Anomaly Detection and Prediction</b> [<a href="https://drive.google.com/file/d/1FQxeZNacNw1iYYo6e4uQB5FUWkG0sQ9M/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1L977sDPKmBZsDVBwpziW6toM_Ndvp9B1/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Chathurangi Shyalika, Harleen Kaur Bagga, Ahan Bhatt, Renjith Prasad, Alaa Al Ghazo, Amit Sheth</li>
     <br>
-    <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Navigating the High-Dimensional Frontier: Anomaly Detection with Limited Data</b> [<a href="https://drive.google.com/file/d/1GPxOp-JFc46LpUNrTXNTWUDYJuIfv1DQ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/18FAa_hx5UlPmtF34qsVvkuIy1qLR-kbr/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Ayush Shah, Apurva Narayan, Oleg Iegorov </li>
     <br>
-    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Contrastive Pretraining for Efficient Anomaly Detection in High-Energy Physics</b> [<a href="https://drive.google.com/file/d/1XHHGJ6kN5FN04mD_b6RKOALqXISHxCnf/view?usp=drive_link" target="_blank">PDF</a>] [<a href="" target="_blank">Poster</a>]<br>
         Authors: Samuel Bright-Thonney, Christina Reissel, Gaia Grosso, Philip Harris</li>
     <br>
-    <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Anomaly Detection in the CMS L1 Trigger</b> [<a href="https://drive.google.com/file/d/1dZYVy_x5woopP2zW8DSIb8YzhtInWT7C/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1TPUz93Gt73qwCZoy2j77wxniYH5bAaFe/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Author: Written by Melissa Quinnan on behalf of the CMS Collaboration </li>
     <br>
-    <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Anomaly Detection for Hybrid Butterfly Subspecies via Probability Filtering</b> [<a href="https://drive.google.com/file/d/14KBJjAZ5K0hjj2h4V7_oyflnaEGZq0fr/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1p6gUc-v5o606FJLCL3sPbNWcNcuspdAk/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Bo-Kai Ruan, Yi-Zeng Fang, Hong-Han Shuai, Juinn-Dar Huang </li>
     <br>
-    <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link" target="_blank">PDF</a>] <br>
+    <li><b>Adaptive Sparsified Graph Learning Framework for Vessel Behavior Anomalies</b> [<a href="https://drive.google.com/file/d/1Ge9FVHRBfEupuvfsIPDBiZDSDk6uXsxZ/view?usp=drive_link" target="_blank">PDF</a>] [<a href="https://drive.google.com/file/d/1VFW5IUuD-t9NozOBgakUblbPdr0iJkAd/view?usp=drive_link" target="_blank">Poster</a>]<br>
         Authors: Jeehong Kim, Minchan Kim, Jaeseong Ju, Youngseok Hwang, Wonhee Lee, Hyunwoo Park </li>
     </ol>
 

--- a/aaai-workshop2024.html
+++ b/aaai-workshop2024.html
@@ -49,15 +49,40 @@
     </div>
 
     <hr>
-        
+    <div id="schedule">
     <p><b>9:00 - 9:10am</b>: Opening Remarks</p>
-    <p><b>9:10 - 9:45am</b>: Talk 1</p>
-    <p><b>9:45 - 10:20am</b>: Talk 2</p>
-    <p><b>10:30 - 11:00am</b>: Coffee Break</p>
-    <p><b>11:00 - 11:20am</b>: Poster Session (<a href="#papers-posters">Papers and Associated Posters</a>)</p>
-    <p><b>11:20 - 11:35am</b>: Contributed Talk</p>
-    <p><b>11:35 - 11:50am</b>: Contributed Talk</p>
-    <p><b>11:50 - 12:30pm</b>: Talk 3</p>
+    <p><b>9:10 - 9:45am</b>: Eric Nalisnick&mdash;<b>Anomalous Anomalies: Monitoring and Adapting Anomaly Detectors</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/enalisnick/enalisnick.github.io/blob/master/Nalisnick_Headshot.jpeg?raw=true" alt="image of Eric Nalisnick" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Eric Nalisnick is an assistant professor at Johns Hopkins University. His research interests span statistical machine learning and probabilistic modeling, with an emphasis on quantifying uncertainty in deep learning, human-AI collaboration, specifying prior knowledge, and detecting distribution shift. He previously was an assistant professor at the University of Amsterdam, a postdoctoral researcher at the University of Cambridge and a PhD student at the University of California, Irvine. Eric has also held research positions at DeepMind, Microsoft, Twitter, and Amazon. His papers have been recognized with selective oral presentations (ECCV 2024) and awards (AIStats 2023, AIStats 2024).</p>
+            <p><b>Abstract:</b> Anomaly detectors perform essential tasks ranging from protecting an autonomous system from abnormal inputs to isolating interesting scientific signals that may lead to discovery.  However, how do we know that the anomaly detector will be robust?  The detector itself could be susceptible to failure if there is a change in the distribution of anomalies expected.  And to make matters worse, we usually don't have an abundance of test-time anomalies that are labeled as such.  In this talk, I will discuss my group's recent work on monitoring if our anomaly detector is still valid and adapting it to data shift, without supervision.</p>
+        </details></p>
+    <p><b>9:45 - 10:20am</b>: Jennifer Ngadiuba&mdash;<b>Boosting sensitivity to new physics at the LHC with anomaly detection</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/user-attachments/assets/5e2532ee-0090-4725-8bb8-58cee458e3ea" alt="image of Jennifer Ngadiuba" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Jennifer Ngadiuba, a Wilson Fellow at Fermilab since 2021, specializes in searching for new physics in collider data and advancing AI applications in high-energy physics. After earning her Ph.D. from the University of Zurich, she contributed to CMS experiment studies, focusing on diboson resonances and jet substructure techniques. Starting when she was research fellow at CERN and Caltech, she pioneered deep learning for anomaly detection and fast machine learning on FPGAs for real-time systems in particle physics. Her work earned her the DOE AI4HEP award and AI2050 fellowship in 2023, recognizing her transformative contributions to experimental physics and machine learning.</p>
+            <p><b>Abstract:</b> Anomaly detection techniques have been proposed as a way to mitigate the impact of
+                model-specific assumptions when searching for new physics at the LHC. In this talk I will
+                discuss how these techniques, when based on modern AI developments, could be utilized
+                at different stages of data processing workflow, from real-time systems to offline analysis,
+                and the impact they could have to revolutionize the current paradigms in the search for
+                new physics.</p>
+        </details></p>
+    <p><b>10:30 - 11:30am</b>: Coffee Break and Poster Session (<a href="#papers-posters">Papers and Associated Posters</a>)</p>
+    <p><b>11:30 - 12:10pm</b>: Adji Bousso Dieng&mdash;<b>Vendi Scoring For Discovery</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p><img src="https://github.com/user-attachments/assets/6d59be74-c5de-4104-8077-eebdeddd20ad" alt="image of Adji Bousso Dieng" width="200" style="float: left; padding: 0px 5px 5px 0px;"><br clear="right">
+            <b>Bio:</b> Adji Bousso Dieng is an Assistant Professor of Computer Science at Princeton University where she leads the lab Vertaix on research at the intersection of artificial intelligence and the natural sciences. She is affiliated with the Chemical and Biological Engineering Department, the Princeton Materials Institute, the Princeton Quantum Initiative, the Andlinger Center for Energy and the Environment, and the High Meadows Environmental Institute (HMEI) at Princeton. She is also a Research Scientist at Google AI and the founder and President of the nonprofit The Africa I Know. She has been recently named an Early-Career Distinguished Presenter at the MRS Spring Meeting,  one of 10 African Scholars to watch in 2025 by The Africa Report, an Outstanding Recent Alumni by Columbia University's Grad School of Arts and Sciences, an AI2050 Early Career Fellow by Schmidt Sciences, and as the Annie T. Randall Innovator of 2022 for her research and advocacy by the American Statistical Association. She received her Ph.D. from Columbia University. Her doctoral work received many recognitions, including a Google Ph.D. Fellowship in Machine Learning, a rising star in Machine Learning nomination by the University of Maryland, and a Savage Award from the International Society for Bayesian Analysis, for her doctoral thesis. Dieng's research has been covered in media such as the New Scientist and TechXplore. She hails from Kaolack, Senegal. </p>
+            <p><b>Abstract:</b> This talk will cover the concepts, tools, and methods that make up Vendi Scoring, a new research direction focused on the concept of diversity. I’ll begin by introducing the Vendi Scores, a family of diversity metrics rooted in ecology and quantum mechanics, along with their extensions. Next, I’ll discuss algorithms for efficiently searching large materials databases and exploring complex energy landscapes, such as those found in molecular simulations, using the Vendi Scores. Finally, I’ll introduce the new concept of 'algorithmic microscopy,' which stems from Vendi Scoring, and describe the Vendiscope, the first algorithmic microscope designed to help scientists zoom in on large data collections for data-driven discovery.</p>
+        </details></p>
+    <p><b>12:10 - 12:30pm</b>: Contributed Talk&mdash;<b>TBD</b>
+        <details name="speaker-info">
+            <summary>Details</summary>
+            <p>TBD</p>
+        </details></p>
     <p><b>12:30 - 2:00pm</b>: Lunch (not provided)</p>
     <p><b>2:00 - 2:10pm</b>: Challenge Overview</p>
     <p><b>2:10 - 2:50pm</b>: Butterfly Challenge Talk</p>
@@ -65,8 +90,8 @@
     <p><b>3:30 - 4:00pm</b>: Coffee Break</p>
     <p><b>4:00 - 4:40pm</b>: Sea Level Rise Challenge Talk</p>
     <p><b>4:40 - 5:00pm</b>: Overall Challenge Talk</p>
-    <p><b>5:00 - 5:30pm</b>: Closing Remarks</p>
-
+    <p><b>5:00 - 5:30pm</b>: Closing Remarks and Discussion of Next Challenge</p>
+    </div>
 
     <hr>
 

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -46,7 +46,7 @@
                     data-tooltip="Team: &#10;Marta Babicz (University of Zürich), &#10;Saul Alonso-Monsalve (ETH Zurich) ">
                     salonsom(Team one)</li>
             </ol>
-            <h3>iHarp Water-level Challenge<span id="iharp-winner"></span></h3>
+            <h3>iHarp Sea Level Rise Challenge<span id="iharp-winner"></span></h3>
             <ol class="emoji-list">
                 <li data-tooltip="Team: &#10; Cheng-Han Tsai (National Tsinghua University)">tsaichenghan</li>
                 <li data-tooltip="Team: &#10; Motoki Saitama (KBC Bank)">motoki</li>

--- a/styles.css
+++ b/styles.css
@@ -499,35 +499,3 @@ summary {
     font-size: 0.9em;
     white-space: pre-line;
 }
-
-/* Container for the entire details block */
-.speaker-container {
-    margin-top: 10px;
-}
-
-/* Bio header styled to appear on its own line */
-.speaker-bio-heading {
-    font-size: 1.1rem;
-    margin: 0 0 8px 0;
-    text-align: left;
-}
-
-/* Flex container for image and text */
-.speaker-details {
-    display: flex;
-    gap: 15px;
-    align-items: flex-start;
-    margin-bottom: 10px;
-}
-
-/* Speaker image styling */
-.speaker-image img {
-    width: 200px;
-    /* Adjust size as needed */
-    border-radius: 5px;
-}
-
-/* Ensure speaker text takes the remaining space */
-.speaker-text {
-    flex-grow: 1;
-}

--- a/styles.css
+++ b/styles.css
@@ -370,3 +370,11 @@ ol, ul {
 li {
     text-align: left;    /* Align individual list items to the left */
 }
+
+details {
+    margin-left: 1em;
+  }
+
+summary {
+    margin-left: -40em;
+}

--- a/styles.css
+++ b/styles.css
@@ -499,3 +499,35 @@ summary {
     font-size: 0.9em;
     white-space: pre-line;
 }
+
+/* Container for the entire details block */
+.speaker-container {
+    margin-top: 10px;
+}
+
+/* Bio header styled to appear on its own line */
+.speaker-bio-heading {
+    font-size: 1.1rem;
+    margin: 0 0 8px 0;
+    text-align: left;
+}
+
+/* Flex container for image and text */
+.speaker-details {
+    display: flex;
+    gap: 15px;
+    align-items: flex-start;
+    margin-bottom: 10px;
+}
+
+/* Speaker image styling */
+.speaker-image img {
+    width: 200px;
+    /* Adjust size as needed */
+    border-radius: 5px;
+}
+
+/* Ensure speaker text takes the remaining space */
+.speaker-text {
+    flex-grow: 1;
+}

--- a/styles.css
+++ b/styles.css
@@ -403,13 +403,54 @@ ul {
 
 /* Optionally, to ensure uniformity */
 li {
-    text-align: left;    
+    text-align: left;
     /* Align individual list items to the left */
 }
 
+/* Style the details container */
 details {
-    margin-left: 1em;
-  }
+    background: #f1f1f1;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 10px 15px;
+    margin-bottom: 1em;
+    transition: all 0.3s ease;
+}
+
+/* Style the summary (the clickable element) */
+details summary {
+    font-weight: bold;
+    cursor: pointer;
+    list-style: none;
+    /* Hides default marker */
+    outline: none;
+}
+
+/* Remove the default marker */
+details summary::-webkit-details-marker {
+    display: none;
+}
+
+/* Add a custom marker. It rotates when the details are open */
+details summary::before {
+    content: "➕";
+    display: inline-block;
+    margin-right: 10px;
+    transition: transform 0.3s ease;
+}
+
+details[open] summary::before {
+    content: "➖";
+    transform: rotate(180deg);
+}
+
+/* Optional: Style the content inside details */
+details p,
+details div,
+details li {
+    margin: 0.5em 0;
+    line-height: 1.4;
+}
 
 summary {
     margin-left: -40em;


### PR DESCRIPTION
Workshop schedule has collapsible tabs for speaker details (the formatting could probably use some improvement @ytchoutw). All papers and posters are linked.
![Screenshot 2025-02-26 at 3 28 18 PM](https://github.com/user-attachments/assets/4ea1a806-7f81-4463-9049-93fe3c2543a9)
![Screenshot 2025-02-26 at 3 29 34 PM](https://github.com/user-attachments/assets/5a40381a-7662-4e61-b2db-b043581290da)
